### PR TITLE
캘린더 조건 수정

### DIFF
--- a/PlantingMind/PlantingMind/Calender/CalendarGridView.swift
+++ b/PlantingMind/PlantingMind/Calender/CalendarGridView.swift
@@ -16,7 +16,7 @@ struct CalendarGridView: View {
             ForEach(viewModel.days, id: \.self) { item in
                 if let item = item {
                     let moodRecord = viewModel.mood(of: item)
-                    DayCellView(viewModel: DayCellViewModel(calendarModel: item, moodRecord: moodRecord))
+                    DayCellView(viewModel: DayCellViewModel(today: viewModel.today, calendarModel: item, moodRecord: moodRecord))
                 } else {
                     RoundedRectangle(cornerRadius: 5)
                         .foregroundColor(Color.clear)

--- a/PlantingMind/PlantingMind/Calender/CalendarHeaderView.swift
+++ b/PlantingMind/PlantingMind/Calender/CalendarHeaderView.swift
@@ -26,9 +26,14 @@ struct CalendarHeaderView: View {
                     .font(.title)
             })
             
-            Text(calendarViewModel.currentDate, formatter: calendarViewModel.dateFormatter)
-                .font(.title)
-                .fontWeight(.bold)
+            Button {
+                // TODO: datePicker
+            } label: {
+                Text(calendarViewModel.currentDate, formatter: calendarViewModel.dateFormatter)
+                    .font(.title)
+                    .fontWeight(.bold)
+            }
+            .buttonStyle(PlainButtonStyle())
             
             Button(action: {
                 calendarViewModel.addingMonth(value: 1)

--- a/PlantingMind/PlantingMind/Calender/CalendarViewModel.swift
+++ b/PlantingMind/PlantingMind/Calender/CalendarViewModel.swift
@@ -12,7 +12,7 @@ import Combine
 class CalendarViewModel: ObservableObject {
     private let context: NSManagedObjectContext
     private let startMonth: Date? = Calendar.current.date(from: DateComponents(year: 2024, month: 1, day: 1))
-    private var today: Date
+    private(set) var today: Date
     private var cancellables: Set<AnyCancellable>
     
     private var calendar: Calendar {

--- a/PlantingMind/PlantingMind/Calender/DayCellView.swift
+++ b/PlantingMind/PlantingMind/Calender/DayCellView.swift
@@ -10,13 +10,18 @@ import SwiftUI
 struct DayCellView: View {
     @Environment(\.managedObjectContext) var context
     @State var showMoodRecordView: Bool = false
+    @State var showAlert: Bool = false
     
     var viewModel: DayCellViewModel
     
     var body: some View {
         VStack(spacing: -5) {
             Button(action: {
-                showMoodRecordView.toggle()
+                if viewModel.isFutureDate {
+                    showAlert.toggle()
+                } else {
+                    showMoodRecordView.toggle()
+                }
             }, label: {
                 Text("\(viewModel.calendarModel.day)")
                     .frame(width: 30, height: 30)
@@ -32,6 +37,7 @@ struct DayCellView: View {
                                                               moodRecord: viewModel.moodRecord))
                 .interactiveDismissDisabled(true)
             }
+            .disabled(viewModel.isFutureDate)
             
             RoundedRectangle(cornerRadius: 5)
                 .frame(height: 16)
@@ -44,6 +50,6 @@ struct DayCellView: View {
 }
 
 #Preview {
-    DayCellView(viewModel: DayCellViewModel(calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: true),
+    DayCellView(viewModel: DayCellViewModel(today: Date(), calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: true),
                                             moodRecord: MoodRecord(context: CoreDataStack(.inMemory).persistentContainer.viewContext)))
 }

--- a/PlantingMind/PlantingMind/Calender/DayCellViewModel.swift
+++ b/PlantingMind/PlantingMind/Calender/DayCellViewModel.swift
@@ -8,7 +8,8 @@
 import Foundation
 import SwiftUI
 
-struct DayCellViewModel {
+class DayCellViewModel: ObservableObject {
+    let today: Date
     let moodRecord: MoodRecord?
     let calendarModel: CalendarModel
     
@@ -18,7 +19,11 @@ struct DayCellViewModel {
     }
     
     var dayForegroundColor: Color {
-        self.calendarModel.isToday ? Color.Custom.point : Color.Custom.general
+        if self.isFutureDate {
+            return Color.gray
+        } else {
+            return self.calendarModel.isToday ? Color.Custom.point : Color.Custom.general
+        }
     }
     
     var dayBackgroundColor: Color {
@@ -35,7 +40,15 @@ struct DayCellViewModel {
         return Image(mood.emojiName, bundle: nil)
     }
     
-    init(calendarModel: CalendarModel, moodRecord: MoodRecord?) {
+    var isFutureDate: Bool {
+        guard let date = Calendar.current.date(from: DateComponents(year: self.calendarModel.year,
+                                                                    month: self.calendarModel.month,
+                                                                    day: self.calendarModel.day)) else { return false }
+        return date > self.today
+    }
+    
+    init(today: Date, calendarModel: CalendarModel, moodRecord: MoodRecord?) {
+        self.today = today
         self.calendarModel = calendarModel
         self.moodRecord = moodRecord
     }

--- a/PlantingMind/PlantingMindTests/CalendarViewModelTests.swift
+++ b/PlantingMind/PlantingMindTests/CalendarViewModelTests.swift
@@ -35,17 +35,48 @@ final class CalendarViewModelTests: XCTestCase {
     }
     
     func test_이전_달로_이동() throws {
+        let date = Calendar.current.date(from: DateComponents(year: 2024,
+                                                              month: 2,
+                                                              day: 1))
+        
+        viewModel = CalendarViewModel(today: date!, context: context)
         viewModel.addingMonth(value: -1)
         
         let nilCount = viewModel.days.filter { $0 == nil }.count
-        XCTAssertEqual(nilCount, 5) // 23년 12월은 금요일부터 시작이므로 nil이 5개 있어야 한다.
+        XCTAssertEqual(nilCount, 1) // 24년 1월은 월요일부터 시작이므로 nil이 1개 있어야 한다.
+    }
+    
+    func test_2024년_1월_이전으로_이동하려는_경우_막기() throws {
+        viewModel.addingMonth(value: -1)
+        
+        // 1월 이전으로 돌아가지 않아야 하므로 nil 갯수 변화 없어야 한다.
+        let expectedNilCount = 1
+        let nilCount = viewModel.days.filter { $0 == nil }.count
+        XCTAssertEqual(nilCount, expectedNilCount)
     }
     
     func test_다음_달로_이동() throws {
+        let date = Calendar.current.date(from: DateComponents(year: 2024,
+                                                              month: 2,
+                                                              day: 1))
+        
+        viewModel = CalendarViewModel(today: date!, context: context)
+        viewModel.currentDate = Calendar.current.date(from: DateComponents(year: 2024,
+                                                                           month: 1,
+                                                                           day: 1))!
         viewModel.addingMonth(value: 1)
         
         let nilCount = viewModel.days.filter { $0 == nil }.count
-        XCTAssertEqual(nilCount, 4) // 24년 2월은 목요일부터 시작이므로 nil이 하나 있어야 한다.
+        XCTAssertEqual(nilCount, 4) // 24년 2월은 목요일부터 시작이므로 nil이 4개 있어야 한다.
+    }
+    
+    func test_현재_달의_다음_달로_이동하려는_경우_막기() throws {
+        viewModel.addingMonth(value: 1)
+        
+        // 현재 달의 다음달로 넘어가지 않아야 하므로 nil 갯수 변화 없어야 한다.
+        let expectedNilCount = 1
+        let nilCount = viewModel.days.filter { $0 == nil }.count
+        XCTAssertEqual(nilCount, expectedNilCount)
     }
     
     func test_해당_월의_mood_list_가져오기() throws {

--- a/PlantingMind/PlantingMindTests/DayCellViewModelTest.swift
+++ b/PlantingMind/PlantingMindTests/DayCellViewModelTest.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 final class DayCellViewModelTest: XCTestCase {
     func test_DayCellModel_record_nil() throws {
-        let model = DayCellViewModel(calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: false),
+        let model = DayCellViewModel(today: Date(), calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: false),
                                      moodRecord: nil)
         
         XCTAssertNil(model.mood)
@@ -25,7 +25,7 @@ final class DayCellViewModelTest: XCTestCase {
         moodRecord.timestamp = "2024-02-24"
         moodRecord.mood = Mood.nice.rawValue
         
-        let model = DayCellViewModel(calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: false),
+        let model = DayCellViewModel(today: Date(), calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: false),
                                      moodRecord: moodRecord)
         
         XCTAssertEqual(Mood.nice, model.mood)
@@ -34,7 +34,7 @@ final class DayCellViewModelTest: XCTestCase {
     }
     
     func test_isToday_true_날짜색() throws {
-        let model = DayCellViewModel(calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: true),
+        let model = DayCellViewModel(today: Date(), calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: true),
                                      moodRecord: nil)
         
         XCTAssertEqual(model.dayForegroundColor, Color.Custom.point)
@@ -42,10 +42,46 @@ final class DayCellViewModelTest: XCTestCase {
     }
     
     func test_isToday_false_날짜색() throws {
-        let model = DayCellViewModel(calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: false),
+        let model = DayCellViewModel(today: Date(), calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: false),
                                      moodRecord: nil)
         
         XCTAssertEqual(model.dayForegroundColor, Color.Custom.general)
         XCTAssertEqual(model.dayBackgroundColor, .clear)
+    }
+    
+    func test_미래_날짜색은_회색() throws {
+        let today = try XCTUnwrap(Calendar.current.date(from: DateComponents(year: 2024, month: 1, day: 24)))
+        let model = DayCellViewModel(today: today, calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: false),
+                                     moodRecord: nil)
+        
+        XCTAssertEqual(model.dayForegroundColor, Color.gray)
+    }
+    
+    func test_isFutureDate_보여줄_날짜가_오늘보다_과거() throws {
+        let model = DayCellViewModel(today: Date(),
+                                     calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: false),
+                                     moodRecord: nil)
+        
+        XCTAssertFalse(model.isFutureDate)
+    }
+    
+    func test_isFutureDate_보여줄_날짜가_오늘보다_미래() throws {
+        let today = try XCTUnwrap(Calendar.current.date(from: DateComponents(year: 2024, month: 1, day: 1)))
+        
+        let model = DayCellViewModel(today: today,
+                                     calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: false),
+                                     moodRecord: nil)
+        
+        XCTAssertTrue(model.isFutureDate)
+    }
+    
+    func test_isFutureDate_보여줄_날짜가_오늘() throws {
+        let today = try XCTUnwrap(Calendar.current.date(from: DateComponents(year: 2024, month: 2, day: 24)))
+        
+        let model = DayCellViewModel(today: today,
+                                     calendarModel: CalendarModel(year: 2024, month: 2, day: 24, isToday: true),
+                                     moodRecord: nil)
+        
+        XCTAssertFalse(model.isFutureDate)
     }
 }


### PR DESCRIPTION
- 캘린더 이동 조건 추가
   - 24년 1월 1일 이전으로 가지 못함, 현재 달 이후로 넘어가지 못함.
- 오늘의 날짜보다 미래의 날짜인 경우, 기분 기록을 하지 못하도록 버튼 Disabled 처리
<img width="460" alt="image" src="https://github.com/eunjooChoi/Planting-Mind/assets/22000470/1e3d9939-bd7f-4d57-8b37-55f3d1d60f9d">
