### PR TITLE
감정 기록 화면에서 저장할 때 update가 아닌 새로 저장되고 있던 로직 수정

### DIFF
--- a/PlantingMind/PlantingMind/MoodRecord/MoodRecordView.swift
+++ b/PlantingMind/PlantingMind/MoodRecord/MoodRecordView.swift
@@ -79,7 +79,7 @@ struct MoodRecordView: View {
                             Spacer()
                             HStack {
                                 Spacer()
-                                Text("\(viewModel.reason.count) / 100")
+                                Text("text_limit".localized(with: [viewModel.reason.count]))
                                     .foregroundStyle(Color.Custom.line)
                                     .padding(.bottom, 10)
                                     .padding(.trailing, 28)

--- a/PlantingMind/PlantingMind/MoodRecord/MoodRecordViewModel.swift
+++ b/PlantingMind/PlantingMind/MoodRecord/MoodRecordViewModel.swift
@@ -29,12 +29,23 @@ class MoodRecordViewModel: ObservableObject {
         guard let date = self.date else { return }
         let timestamp = date.timeStampString()
         
-        let record = MoodRecord(context: context)
-        record.timestamp = timestamp
-        record.mood = self.mood.rawValue
-        record.reason = self.reason
+        let fetchRequest = NSFetchRequest<MoodRecord>(entityName: "MoodRecord")
+        let predicate = NSPredicate(format: "timestamp == %@", timestamp)
+        fetchRequest.predicate = predicate
         
         do {
+            let result = try context.fetch(fetchRequest)
+            
+            if result.count == 1 {
+                let record = result[0]
+                record.mood = self.mood.rawValue
+                record.reason = self.reason
+            } else {
+                let record = MoodRecord(context: context)
+                record.timestamp = timestamp
+                record.mood = self.mood.rawValue
+                record.reason = self.reason
+            }
             try context.save()
         } catch {
             print("Failed to save the mood record", error.localizedDescription)

--- a/PlantingMind/PlantingMindTests/MoodRecordViewModelTests.swift
+++ b/PlantingMind/PlantingMindTests/MoodRecordViewModelTests.swift
@@ -63,6 +63,8 @@ final class MoodRecordViewModelTests: XCTestCase {
                                             calendarModel: calendarModel,
                                             moodRecord: moodRecord)
         
+        viewModel.save()
+        
         let expectedMood = Mood.normal
         let expectedReason = "Change Reason"
         


### PR DESCRIPTION
- 기존의 데이터를 가져온 이후 해당 기록을 수정하도록 함.