### PR TITLE
코드 커버리지 옵션 on으로 변경

### DIFF
--- a/PlantingMind/PlantingMind.xctestplan
+++ b/PlantingMind/PlantingMind.xctestplan
@@ -9,7 +9,6 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
     "targetForVariableExpansion" : {
       "containerPath" : "container:PlantingMind.xcodeproj",
       "identifier" : "7B11F8232B4549DF00346A41",


### PR DESCRIPTION
github action의 test 툴에서는 Code coverage 기본값이 true로 되어있고, Code coverage가 존재하는 경우 결과를 노출하는데, 프로젝트 설저의 코드 커버리지 옵션이 Off로 되어있었음.

<img width="633" alt="image" src="https://github.com/eunjooChoi/Planting-Mind/assets/22000470/f38b388e-3571-40dd-9fcf-bfb646fad86e">
