### PR TITLE
마음 현황 수정

### DIFF
--- a/PlantingMind/PlantingMind.xcodeproj/project.pbxproj
+++ b/PlantingMind/PlantingMind.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		7B0A76D12B906FE100ADC039 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A76D02B906FE100ADC039 /* CoreDataStack.swift */; };
 		7B0A77112B93196D00ADC039 /* MoodRecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A77102B93196D00ADC039 /* MoodRecordViewModel.swift */; };
 		7B0E1BCE2BAD57940060458D /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 7B95D1792BA1645C00484F9D /* Localizable.xcstrings */; };
-		7B0E1BCF2BAD57A70060458D /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B95D17B2BA166AC00484F9D /* StringExtension.swift */; };
 		7B0E1BD32BAD6C240060458D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B11F82B2B4549E000346A41 /* Assets.xcassets */; };
 		7B0E1BD62BB15A220060458D /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7B0E1BD52BB15A220060458D /* Pretendard-Black.otf */; };
 		7B0E1BD72BB15A220060458D /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7B0E1BD52BB15A220060458D /* Pretendard-Black.otf */; };
@@ -55,6 +54,7 @@
 		7BAB04F42B9466BC00948CF2 /* Mood.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BAB04F32B9466BC00948CF2 /* Mood.swift */; };
 		7BAB04F62B946B8700948CF2 /* MoodRecordViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BAB04F52B946B8700948CF2 /* MoodRecordViewModelTests.swift */; };
 		7BABB0112B5F850200EEEEBB /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BABB0102B5F850200EEEEBB /* ColorExtension.swift */; };
+		7BAEFB282BBBE4EF00116B9E /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B95D17B2BA166AC00484F9D /* StringExtension.swift */; };
 		7BC300F22B5E4A3E00059068 /* CalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC300F12B5E4A3E00059068 /* CalendarViewModel.swift */; };
 		7BC300F52B5E4CE100059068 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC300F42B5E4CE100059068 /* CalendarView.swift */; };
 		7BC300F72B5E525900059068 /* CalendarModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC300F62B5E525900059068 /* CalendarModel.swift */; };
@@ -591,7 +591,7 @@
 				7B63CAA52BA9CB4600943DED /* PlantingWidget.swift in Sources */,
 				7BA079972BAAD87A009B5E46 /* ColorExtension.swift in Sources */,
 				7BA079962BAAD834009B5E46 /* Mood.swift in Sources */,
-				7B0E1BCF2BAD57A70060458D /* StringExtension.swift in Sources */,
+				7BAEFB282BBBE4EF00116B9E /* StringExtension.swift in Sources */,
 				7BA079952BAAD669009B5E46 /* MoodRecords.xcdatamodeld in Sources */,
 				7B63CAA32BA9CB4600943DED /* PlantingWidgetBundle.swift in Sources */,
 				7BA079932BAAD662009B5E46 /* MoodRecord+CoreDataClass.swift in Sources */,

--- a/PlantingMind/PlantingMind/Calender/Analysis/AnalysisView.swift
+++ b/PlantingMind/PlantingMind/Calender/Analysis/AnalysisView.swift
@@ -22,21 +22,35 @@ struct AnalysisView: View {
             Text("mood_statistics")
                 .font(.title3)
                 .bold()
-                .padding([.top, .horizontal])
+                .padding()
             
-            Chart(viewModel.moodAnalysis, id: \.self) {
-                BarMark(x: .value("Count", $0.count))
-                .foregroundStyle(by: .value("Category", $0.mood))
+            Chart(viewModel.moodAnalysis, id: \.mood) { analysis in
+                BarMark(x: .value("Count", analysis.count))
+                    .foregroundStyle(by: .value("Category", analysis.mood.moodString))
+                    .annotation(position: .overlay, alignment: .center) {
+                        let color: Color = analysis.mood == Mood.nice ? .black : .white
+                        
+                        Text("\(analysis.count)")
+                            .foregroundStyle(color)
+                            .font(.caption)
+                            .bold()
+                    }
             }
             .chartForegroundStyleScale([
-                "nice": Mood.nice.color,
-                "good": Mood.good.color,
-                "normal": Mood.normal.color,
-                "notBad": Mood.notBad.color,
-                "bad": Mood.bad.color
+                Mood.nice.moodString: Mood.nice.color,
+                Mood.good.moodString: Mood.good.color,
+                Mood.normal.moodString: Mood.normal.color,
+                Mood.notBad.moodString: Mood.notBad.color,
+                Mood.bad.moodString: Mood.bad.color
             ])
-            .frame(height: 60)
-            .padding()
+            .chartXScale(domain: 0...viewModel.recordsCount)
+            .chartXAxis {
+                AxisMarks(position: .bottom) { _ in
+                     AxisGridLine().foregroundStyle(.clear)
+                     AxisTick().foregroundStyle(.clear)
+                }
+            }
+            .frame(height: 50)
         }
     }
 }

--- a/PlantingMind/PlantingMind/Calender/Analysis/AnalysisViewModel.swift
+++ b/PlantingMind/PlantingMind/Calender/Analysis/AnalysisViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 struct AnalysisViewModel {
     let moodAnalysis: [MoodAnalysis]
@@ -18,7 +19,7 @@ struct AnalysisViewModel {
         var result: [MoodAnalysis] = []
         for mood in Mood.allCases {
             let count = moods.filter { $0.mood == mood.rawValue }.count
-            result.append(MoodAnalysis(mood: mood.rawValue, count: count))
+            result.append(MoodAnalysis(mood: mood, count: count))
         }
         
         self.moodAnalysis = result

--- a/PlantingMind/PlantingMind/Calender/Analysis/MoodAnalysisModel.swift
+++ b/PlantingMind/PlantingMind/Calender/Analysis/MoodAnalysisModel.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct MoodAnalysis: Hashable {
-    let mood: String
+    let mood: Mood
     let count: Int
 }

--- a/PlantingMind/PlantingMind/Localization/Localizable.xcstrings
+++ b/PlantingMind/PlantingMind/Localization/Localizable.xcstrings
@@ -18,6 +18,23 @@
         }
       }
     },
+    "bad" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bad"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "나쁨"
+          }
+        }
+      }
+    },
     "cancel" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -98,6 +115,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ㄱ"
+          }
+        }
+      }
+    },
+    "good" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Good"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "좋음"
           }
         }
       }
@@ -183,6 +217,57 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "오늘은 어땠어요?"
+          }
+        }
+      }
+    },
+    "nice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nice"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아주 좋음"
+          }
+        }
+      }
+    },
+    "normal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So-so"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "그저 그럼"
+          }
+        }
+      }
+    },
+    "notBad" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Bad"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "나쁘진 않음"
           }
         }
       }

--- a/PlantingMind/PlantingMind/MoodRecord/Mood.swift
+++ b/PlantingMind/PlantingMind/MoodRecord/Mood.swift
@@ -35,4 +35,8 @@ extension Mood {
             Color.Custom.bad
         }
     }
+    
+    var moodString: String {
+        self.rawValue.localized
+    }
 }

--- a/PlantingMind/PlantingMindTests/AnalysisViewModelTests.swift
+++ b/PlantingMind/PlantingMindTests/AnalysisViewModelTests.swift
@@ -20,7 +20,7 @@ final class AnalysisViewModelTests: XCTestCase {
         let record2 = MoodRecord(context: context)
         record2.mood = Mood.bad.rawValue
         
-        var records: [MoodRecord] = [record1, record2]
+        let records: [MoodRecord] = [record1, record2]
         
         viewModel = AnalysisViewModel(moods: records)
     }


### PR DESCRIPTION
- 차트 background에 들어가는 Grid 제거
- chartForegroundStyleScale에 노출되는 기분 색인 문구 변경
- bar chart에 각 기분이 몇 개 있는지를 보여주는 Text annotation 추가


<img width="401" alt="image" src="https://github.com/eunjooChoi/Planting-Mind/assets/22000470/05769acc-d2ec-467f-be99-332399f5370d">
