### PR TITLE
감정 기록 화면 수정

### DIFF
--- a/PlantingMind/PlantingMind/Localization/Localizable.xcstrings
+++ b/PlantingMind/PlantingMind/Localization/Localizable.xcstrings
@@ -165,7 +165,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "왜 그렇게 느꼈어요?"
+            "value" : "무슨 일이 있었나요?"
           }
         }
       }
@@ -249,7 +249,7 @@
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "그저 그럼"
           }
         }

--- a/PlantingMind/PlantingMind/Localization/Localizable.xcstrings
+++ b/PlantingMind/PlantingMind/Localization/Localizable.xcstrings
@@ -68,6 +68,22 @@
         }
       }
     },
+    "confirm" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Discard Changes"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "변경 사항 폐기"
+          }
+        }
+      }
+    },
     "done" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -268,6 +284,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "나쁘진 않음"
+          }
+        }
+      }
+    },
+    "record_cancel_alert" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to discard changes?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "변경 사항을 폐기하겠습니까?"
           }
         }
       }

--- a/PlantingMind/PlantingMind/MoodRecord/MoodRecordView.swift
+++ b/PlantingMind/PlantingMind/MoodRecord/MoodRecordView.swift
@@ -17,29 +17,15 @@ struct MoodRecordView: View {
         NavigationStack() {
             HStack {
                 VStack(spacing: 20) {
+                    Text("\(viewModel.dateFormatter.string(from: viewModel.date))")
+                        .italic()
+                    
                     Text("mood_title")
                         .font(.title2)
                         .bold()
-                        .padding()
+                        .padding(.horizontal)
                     
-                    HStack(spacing: 20) {
-                        ForEach(Mood.allCases, id: \.self) {mood in
-                            Button(action: {
-                                viewModel.mood = mood
-                            }, label: {
-                                Image("\(mood.rawValue)", label: Text("\(mood.rawValue)"))
-                            })
-                            .buttonStyle(PlainButtonStyle())
-                            .overlay {
-                                if viewModel.mood == mood {
-                                    Circle()
-                                        .stroke(Color.Custom.select, lineWidth: 2)
-                                        .foregroundStyle(.clear)
-                                        .frame(width: 60, height: 60)
-                                }
-                            }
-                        }
-                    }
+                    moodSelectView
                     
                     Spacer()
                     
@@ -48,43 +34,13 @@ struct MoodRecordView: View {
                         .bold()
                     
                     ZStack {
-                        TextEditor(text: $viewModel.reason)
-                            .autocorrectionDisabled(true)
-                            .background(Color.Custom.line)
-                            .opacity(0.8)
-                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                            .padding(.horizontal)
-                            .onChange(of: viewModel.reason) { _ in
-                                if viewModel.reason.count > 100 {
-                                    viewModel.reason.removeLast()
-                                }
-                            }
+                        textEditorView
                         
                         if viewModel.reason.isEmpty {
-                            VStack {
-                                HStack {
-                                    Text("fill_in_the_blank")
-                                        .foregroundStyle(Color.Custom.line)
-                                        .padding(.top, 9)
-                                        .padding(.leading, 22)
-                                    
-                                    Spacer()
-                                }
-                                Spacer()
-                            }
+                            emptyStringView
                         }
                         
-                        VStack {
-                            Spacer()
-                            HStack {
-                                Spacer()
-                                Text("text_limit".localized(with: [viewModel.reason.count]))
-                                    .foregroundStyle(Color.Custom.line)
-                                    .padding(.bottom, 10)
-                                    .padding(.trailing, 28)
-                                
-                            }
-                        }
+                        limitStringView
                     }
                     
                     Spacer()
@@ -109,6 +65,69 @@ struct MoodRecordView: View {
                 }
             }
             .foregroundStyle(Color.Custom.general)
+        }
+    }
+    
+    var moodSelectView: some View {
+        HStack(spacing: 20) {
+            ForEach(Mood.allCases, id: \.self) {mood in
+                Button(action: {
+                    viewModel.mood = mood
+                }, label: {
+                    Image("\(mood.rawValue)", label: Text("\(mood.rawValue)"))
+                })
+                .buttonStyle(PlainButtonStyle())
+                .overlay {
+                    if viewModel.mood == mood {
+                        Circle()
+                            .stroke(Color.Custom.select, lineWidth: 2)
+                            .foregroundStyle(.clear)
+                            .frame(width: 60, height: 60)
+                    }
+                }
+            }
+        }
+    }
+    
+    var textEditorView: some View {
+        TextEditor(text: $viewModel.reason)
+            .autocorrectionDisabled(true)
+            .background(Color.Custom.line)
+            .opacity(0.8)
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .padding(.horizontal)
+            .onChange(of: viewModel.reason) { _ in
+                if viewModel.reason.count > 100 {
+                    viewModel.reason.removeLast()
+                }
+            }
+    }
+    
+    var emptyStringView: some View {
+        VStack {
+            HStack {
+                Text("fill_in_the_blank")
+                    .foregroundStyle(Color.Custom.line)
+                    .padding(.top, 9)
+                    .padding(.leading, 22)
+                
+                Spacer()
+            }
+            Spacer()
+        }
+    }
+    
+    var limitStringView: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Spacer()
+                Text("text_limit".localized(with: [viewModel.reason.count]))
+                    .foregroundStyle(Color.Custom.line)
+                    .padding(.bottom, 10)
+                    .padding(.trailing, 28)
+                
+            }
         }
     }
 }

--- a/PlantingMind/PlantingMind/MoodRecord/MoodRecordView.swift
+++ b/PlantingMind/PlantingMind/MoodRecord/MoodRecordView.swift
@@ -12,6 +12,7 @@ struct MoodRecordView: View {
     @Environment(\.colorScheme) var colorScheme
     
     @ObservedObject var viewModel: MoodRecordViewModel
+    @State var isDialogPresent: Bool = false
     
     var body: some View {
         NavigationStack() {
@@ -49,10 +50,19 @@ struct MoodRecordView: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(action: {
-                        dismiss()
+                        if viewModel.needCancelAlert() {
+                            isDialogPresent = true
+                        } else {
+                            dismiss()
+                        }
                     }, label: {
                         Text("cancel")
                     })
+                    .confirmationDialog("record_cancel_alert", isPresented: $isDialogPresent, titleVisibility: .visible) {
+                        Button("confirm", role: .destructive) {
+                            dismiss()
+                        }
+                    }
                 }
                 
                 ToolbarItem(placement: .topBarTrailing) {

--- a/PlantingMind/PlantingMind/MoodRecord/MoodRecordViewModel.swift
+++ b/PlantingMind/PlantingMind/MoodRecord/MoodRecordViewModel.swift
@@ -11,6 +11,9 @@ import WidgetKit
 
 class MoodRecordViewModel: ObservableObject {
     private let context: NSManagedObjectContext
+    private let originalMood: Mood
+    private let originalReason: String
+    
     let date: Date
     
     @Published var mood: Mood
@@ -28,8 +31,19 @@ class MoodRecordViewModel: ObservableObject {
                                                                month: calendarModel.month,
                                                                day: calendarModel.day)) ?? Date()
         
-        self.mood = Mood(rawValue: moodRecord?.mood ?? Mood.normal.rawValue) ?? .normal
-        self.reason = moodRecord?.reason ?? ""
+        let mood = Mood(rawValue: moodRecord?.mood ?? Mood.normal.rawValue) ?? .normal
+        let reason = moodRecord?.reason ?? ""
+        
+        self.mood = mood
+        self.reason = reason
+        self.originalMood = mood
+        self.originalReason = reason
+    }
+    
+    func needCancelAlert() -> Bool {
+        guard self.originalReason == self.reason else { return true }
+        guard self.originalMood == self.mood else { return true }
+        return false
     }
     
     func save() {

--- a/PlantingMind/PlantingMind/MoodRecord/MoodRecordViewModel.swift
+++ b/PlantingMind/PlantingMind/MoodRecord/MoodRecordViewModel.swift
@@ -11,24 +11,28 @@ import WidgetKit
 
 class MoodRecordViewModel: ObservableObject {
     private let context: NSManagedObjectContext
-    private let date: Date?
+    let date: Date
     
     @Published var mood: Mood
     @Published var reason: String
+    
+    let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy. MM. dd"
+        return formatter
+    }()
     
     init(context: NSManagedObjectContext, calendarModel: CalendarModel, moodRecord: MoodRecord?) {
         self.context = context
         self.date = Calendar.current.date(from: DateComponents(year: calendarModel.year,
                                                                month: calendarModel.month,
-                                                               day: calendarModel.day))
+                                                               day: calendarModel.day)) ?? Date()
         
         self.mood = Mood(rawValue: moodRecord?.mood ?? Mood.normal.rawValue) ?? .normal
         self.reason = moodRecord?.reason ?? ""
     }
     
     func save() {
-        guard let date = self.date else { return }
-        
         let fetchRequest = NSFetchRequest<MoodRecord>(entityName: "MoodRecord")
         let predicate = NSPredicate(format: "timestamp == %@", date as NSDate)
         fetchRequest.predicate = predicate

--- a/PlantingMind/PlantingMindTests/MoodRecordViewModelTests.swift
+++ b/PlantingMind/PlantingMindTests/MoodRecordViewModelTests.swift
@@ -79,6 +79,38 @@ final class MoodRecordViewModelTests: XCTestCase {
         XCTAssertEqual(record?.reason, expectedReason)
     }
     
+    func test_취소했을_때_변경사항_없는_경우() throws {
+        let moodRecord = MoodRecord(context: coreDataStack.persistentContainer.viewContext)
+        moodRecord.mood = Mood.nice.rawValue
+        moodRecord.reason = "reason reason"
+        
+        let viewModel = MoodRecordViewModel(context: coreDataStack.persistentContainer.viewContext,
+                                            calendarModel: calendarModel,
+                                            moodRecord: moodRecord)
+        
+        let expectedResult = false
+        let result = viewModel.needCancelAlert()
+        
+        XCTAssertEqual(expectedResult, result)
+    }
+    
+    func test_취소했을_때_변경사항_있는_경우() throws {
+        let moodRecord = MoodRecord(context: coreDataStack.persistentContainer.viewContext)
+        moodRecord.mood = Mood.nice.rawValue
+        moodRecord.reason = "reason reason"
+        
+        let viewModel = MoodRecordViewModel(context: coreDataStack.persistentContainer.viewContext,
+                                            calendarModel: calendarModel,
+                                            moodRecord: moodRecord)
+        
+        viewModel.mood = Mood.normal
+        
+        let expectedResult = true
+        let result = viewModel.needCancelAlert()
+        
+        XCTAssertEqual(expectedResult, result)
+    }
+    
     func test_notification_발송() throws {
         let viewModel = MoodRecordViewModel(context: coreDataStack.persistentContainer.viewContext,
                                             calendarModel: calendarModel,


### PR DESCRIPTION
- [감정 기록 화면에 날짜를 추가하고 텍스트 뷰 위쪽 문장 수정]
   - MoodRecordView의 구성 요소들을 var로 모두 분리
- 변경 사항이 있는 경우 취소 버튼을 누르면 ConfirmationDialog 노출
   - 테스트 코드 추가

<img width="401" alt="image" src="https://github.com/eunjooChoi/Planting-Mind/assets/22000470/484b3f91-2db7-4f19-9972-34262958e05d">
