### PR TITLE
MonthPicker, 마음 현황 디자인 수정

### DIFF
--- a/PlantingMind/PlantingMind/Calender/Analysis/AnalysisView.swift
+++ b/PlantingMind/PlantingMind/Calender/Analysis/AnalysisView.swift
@@ -28,8 +28,7 @@ struct AnalysisView: View {
                 BarMark(x: .value("Count", analysis.count))
                     .foregroundStyle(by: .value("Category", analysis.mood.moodString))
                     .annotation(position: .overlay, alignment: .center) {
-                        let color: Color = analysis.mood == Mood.nice ? .black : .white
-                        
+                        let color = analysis.mood == .nice ? Color.gray.opacity(0.8) : .white
                         Text("\(analysis.count)")
                             .foregroundStyle(color)
                             .font(.caption)
@@ -46,8 +45,8 @@ struct AnalysisView: View {
             .chartXScale(domain: 0...viewModel.recordsCount)
             .chartXAxis {
                 AxisMarks(position: .bottom) { _ in
-                     AxisGridLine().foregroundStyle(.clear)
-                     AxisTick().foregroundStyle(.clear)
+                    AxisGridLine().foregroundStyle(.clear)
+                    AxisTick().foregroundStyle(.clear)
                 }
             }
             .frame(height: 50)

--- a/PlantingMind/PlantingMind/Calender/Picker/MonthPickerView.swift
+++ b/PlantingMind/PlantingMind/Calender/Picker/MonthPickerView.swift
@@ -79,17 +79,18 @@ struct MonthPickerView: View {
             .labelsHidden()
             .frame(width: 100, height: 200)
             
-            Text(" - ")
+            Text(". ")
                 .font(.title)
+                .bold()
             
             Picker("", selection: $viewModel.selectedMonth) {
                 ForEach(viewModel.months, id: \.self) { month in
-                    Text("\(month)")
+                    Text(String(format: "%02d", month))
                         .bold()
                 }
             }
             .labelsHidden()
-            .frame(width: 50, height: 200)
+            .frame(width: 70, height: 200)
         }
         .pickerStyle(.wheel)
         .compositingGroup()

--- a/PlantingMind/PlantingMind/Calender/Picker/MonthPickerViewModel.swift
+++ b/PlantingMind/PlantingMind/Calender/Picker/MonthPickerViewModel.swift
@@ -87,10 +87,8 @@ class MonthPickerViewModel: ObservableObject {
     func verify(year: Int?) {
         self.updateMonthPicker(year: year)
         
-        //guard let selectedMonth = self.selectedMonth else { return }
-        
         if year == self.years.last,
-           selectedMonth > self.months.count {
+           self.selectedMonth > self.months.count {
             self.selectedMonth = self.months.count
         }
     }


### PR DESCRIPTION
MonthPicker
- '-'를 .으로 변경
- picker width 조정
- 사용하지 않는 ViewModel의 주석 제거

마음 현황
- 들여쓰기 조정
- nice인 경우 gray.opacity(0.8)로 설정