### PR TITLE
위젯 코드 수정

### DIFF
--- a/PlantingMind/PlantingMind/CoreData/MoodRecords.xcdatamodeld/MoodRecords.xcdatamodel/contents
+++ b/PlantingMind/PlantingMind/CoreData/MoodRecords.xcdatamodeld/MoodRecords.xcdatamodel/contents
@@ -2,7 +2,7 @@
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22225" systemVersion="23B81" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="MoodRecord" representedClassName="MoodRecord" syncable="YES">
         <attribute name="mood" attributeType="String" defaultValueString="normal"/>
-        <attribute name="reason" optional="YES" attributeType="String" minValueString="0" maxValueString="101"/>
+        <attribute name="reason" optional="YES" attributeType="String" minValueString="0" maxValueString="10000"/>
         <attribute name="timestamp" attributeType="Date" defaultDateTimeInterval="725731200" usesScalarValueType="NO"/>
     </entity>
 </model>

--- a/PlantingMind/PlantingWidget/PlantingWidget.swift
+++ b/PlantingMind/PlantingWidget/PlantingWidget.swift
@@ -23,16 +23,12 @@ struct Provider: TimelineProvider {
     }
     
     func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
-        var entries: [MoodRecordEntry] = []
-        let currentDate = Calendar.current.nextDate(after: Date(), matching: DateComponents(minute: 0), matchingPolicy: .nextTime) ?? Date()
-        
-        for hourOffset in 0 ..< 5 {
-            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
-            let data = self.fetchMoods()
-            entries = [MoodRecordEntry(date: entryDate, moods: data)]
-        }
-        
-        let timeline = Timeline(entries: entries, policy: .atEnd)
+        let currentDate = Date()
+        let startOfDay = Calendar.current.startOfDay(for: currentDate)
+        let endOfDay = Calendar.current.date(byAdding: .day, value: 1, to: startOfDay)!
+        let data = self.fetchMoods()
+        let entry = MoodRecordEntry(date: startOfDay, moods: data)
+        let timeline = Timeline(entries: [entry], policy: .after(endOfDay))
         completion(timeline)
     }
     
@@ -78,11 +74,10 @@ struct PlantingWidgetEntryView : View {
     
     var body: some View {
         let day = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]
-        let dayCount = Calendar.current.component(.weekday, from: Date())
+        let dayCount = Calendar.current.component(.weekday, from: entry.date)
         
         // 위젯에 기분이 표시되는 날은 오늘 날짜가 표시되는 칸까지
         let blockDisplayRange = brickCount - (weekday - dayCount)
-        
         
         let gridItem = GridItem(.flexible(maximum: 15), spacing: 2)
         


### PR DESCRIPTION
- dayCount를 셀 때 entry.date를 사용하도록 함

## 이슈 이유
- TimeEntry를 추가할 때 view 코드가 실행됨. 엔트리에 추가된 시간마다 view 코드가 돌아가는 것이 아니므로 entry.date를 사용하지 않으면 엔트리가 추가되는 순간의 Date() 시간으로 dayCount를 지정하게 됨. 따라서 12시가 지나도 갱신이 되지 않는 것처럼 보임. entry.date를 사용해 entry가 실행될 순간의 시간으로 계산해야 정상적으로 위젯이 업데이트 됨.

> 일요일에 갱신되는지 확인 후 머지